### PR TITLE
Deploy on tag push, retire deployment branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 
 node_js:
-  - 'node'
+  - 4
+  - 5
 
 script:
   - npm run depcheck -- --web-report
@@ -9,7 +10,11 @@ script:
   - npm run test-coverage
   - cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js
 
+before_deploy:
+  - git checkout -b master
+
 deploy:
   provider: azure_web_apps
   on:
-    branch: deployment
+    tags: true
+    node: 4

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cheerio": "^0.19.0",
     "codecov.io": "^0.1.6",
     "del": "^2.0.2",
-    "depcheck-es6": "^0.5.8",
+    "depcheck": "=0.5.9",
     "eslint": "^1.6.0",
     "eslint-config-airbnb": "^0.1.0",
     "eslint-plugin-react": "^3.6.3",


### PR DESCRIPTION
- Stick on depcheck version 0.5.9.
- Test on both node v4 and v5.
- Hack to deploy Azure on tag push.