### PR TITLE
Deploy from node v5 matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ deploy:
   provider: azure_web_apps
   on:
     tags: true
-    node: 4
+    node: 5
 
 before_deploy:
   - git checkout -b master


### PR DESCRIPTION
- Because build speed of v5 is much faster than v4.