### PR TITLE
Move the prune command to azure deploy script.

### DIFF
--- a/deploy/azure.sh
+++ b/deploy/azure.sh
@@ -115,6 +115,7 @@ selectNodeVersion
 # 3. Install npm packages
 if [ -e "$DEPLOYMENT_TARGET/package.json" ]; then
   cd "$DEPLOYMENT_TARGET"
+  eval $NPM_CMD prune
   eval $NPM_CMD install
   eval $NPM_CMD run build-azure
   exitWithMessageOnError "npm failed"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "npm": "3.x"
   },
   "scripts": {
-    "preinstall": "npm prune",
     "lint": "babel-node ./node_modules/gulp/bin/gulp.js lint",
     "depcheck": "depcheck --ignore-bin-package=false --specials=bin,eslint --ignores=bootstrap,babel-*",
     "build": "babel-node ./node_modules/gulp/bin/gulp.js build",


### PR DESCRIPTION
- Azure is using npm@1.x to run `npm prune`, which fails the deployment.
- The azure deploy script enforce to use npm@3.x to prune.